### PR TITLE
perf: Signature can be calldata

### DIFF
--- a/contracts/interfaces/generic/IERC1271.sol
+++ b/contracts/interfaces/generic/IERC1271.sol
@@ -2,5 +2,5 @@
 pragma solidity ^0.8.0;
 
 interface IERC1271 {
-    function isValidSignature(bytes32 hash, bytes memory signature) external view returns (bytes4 magicValue);
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);
 }

--- a/test/foundry/SignatureChecker.t.sol
+++ b/test/foundry/SignatureChecker.t.sol
@@ -19,11 +19,11 @@ abstract contract TestParameters is TestHelpers {
 }
 
 contract PublicSignatureChecker is SignatureChecker {
-    function recoverEOASigner(bytes32 hash, bytes memory signature) external pure returns (address) {
+    function recoverEOASigner(bytes32 hash, bytes calldata signature) external pure returns (address) {
         return _recoverEOASigner(hash, signature);
     }
 
-    function splitSignature(bytes memory signature)
+    function splitSignature(bytes calldata signature)
         external
         pure
         returns (
@@ -38,7 +38,7 @@ contract PublicSignatureChecker is SignatureChecker {
     function verify(
         bytes32 hash,
         address signer,
-        bytes memory signature
+        bytes calldata signature
     ) external view returns (bool) {
         // It reverts if wrong
         _verify(hash, signer, signature);

--- a/test/foundry/utils/ERC1271Contract.sol
+++ b/test/foundry/utils/ERC1271Contract.sol
@@ -21,7 +21,7 @@ contract ERC1271Contract is IERC1271 {
     /**
      * @notice Verifies that the signer is the owner of the signing contract.
      */
-    function isValidSignature(bytes32 hash, bytes memory signature) external view override returns (bytes4) {
+    function isValidSignature(bytes32 hash, bytes calldata signature) external view override returns (bytes4) {
         uint8 v;
         bytes32 r;
         bytes32 s;
@@ -29,16 +29,16 @@ contract ERC1271Contract is IERC1271 {
         if (signature.length == 64) {
             bytes32 vs;
             assembly {
-                r := mload(add(signature, 0x20))
-                vs := mload(add(signature, 0x40))
+                r := calldataload(signature.offset)
+                vs := calldataload(add(signature.offset, 0x20))
                 s := and(vs, 0x7fffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff)
                 v := add(shr(255, vs), 27)
             }
         } else if (signature.length == 65) {
             assembly {
-                r := mload(add(signature, 0x20))
-                s := mload(add(signature, 0x40))
-                v := byte(0, mload(add(signature, 0x60)))
+                r := calldataload(signature.offset)
+                s := calldataload(add(signature.offset, 0x20))
+                v := byte(0, calldataload(add(signature.offset, 0x40)))
             }
         } else {
             revert WrongSignatureLength(signature.length);


### PR DESCRIPTION
```
testCannotSignIfWrongSignatureEOA() (gas: -301 (-1.191%))
testSignEOA() (gas: -432 (-1.411%))
testCannotSignIfWrongSignatureERC1271() (gas: -31593 (-10.344%))
testSignERC1271() (gas: -31589 (-10.349%))
Overall gas change: -63915 (-23.296%)
```

This is a suggestion coming from a contest participant. Since the signature comes from the calldata and we are never going to modify it, we should consider converting it from `memory` to `calldata` to save gas.

Ref: https://github.com/OpenZeppelin/openzeppelin-contracts/issues/3678