### PR TITLE
perf: OwnableTwoSteps remove SLOAD

### DIFF
--- a/contracts/OwnableTwoSteps.sol
+++ b/contracts/OwnableTwoSteps.sol
@@ -88,7 +88,7 @@ abstract contract OwnableTwoSteps is IOwnableTwoSteps {
         delete ownershipStatus;
         delete potentialOwner;
 
-        emit NewOwner(owner);
+        emit NewOwner(msg.sender);
     }
 
     /**
@@ -101,7 +101,11 @@ abstract contract OwnableTwoSteps is IOwnableTwoSteps {
         ownershipStatus = Status.TransferInProgress;
         potentialOwner = newPotentialOwner;
 
-        emit InitiateOwnershipTransfer(owner, newPotentialOwner);
+        /**
+         * @dev This function can only be called by the owner, so msg.sender is the owner.
+         *      We don't have to SLOAD the owner again.
+         */
+        emit InitiateOwnershipTransfer(msg.sender, newPotentialOwner);
     }
 
     /**


### PR DESCRIPTION
@0xJurassicPunk 

```
testCancelTransferOwnership() (gas: -93 (-0.095%))
testCannotRenounceOrInitiateTransferASecondtime() (gas: -92 (-0.107%))
testTransferOwnershipToNewOwner() (gas: -93 (-0.173%))
testWrongRecipientCannotClaim() (gas: -116 (-0.187%))
Overall gas change: -394 (-0.562%)
```