### PR TITLE
chore: Drop unused functions

### DIFF
--- a/contracts/lowLevelCallers/LowLevelETH.sol
+++ b/contracts/lowLevelCallers/LowLevelETH.sol
@@ -43,30 +43,6 @@ contract LowLevelETH {
     }
 
     /**
-     * @notice Return ETH back to the designated recipient if any ETH is left in the payable call.
-     * @param recipient Recipient address
-     * @dev It does not revert if self balance is equal to 0.
-     */
-    function _returnETHIfAny(address recipient) internal {
-        bool status;
-
-         assembly {
-            let selfBalance := selfbalance()
-
-            switch selfBalance
-            case 0 {
-                status := true
-            }
-            default {
-                status := call(gas(), recipient, selfBalance, 0, 0, 0, 0)
-            }
-
-        }
-
-        if (!status) revert ETHTransferFail();
-    }
-
-    /**
      * @notice Return ETH to the original sender if any is left in the payable call but leave 1 wei of ETH in the contract.
      * @dev It does not revert if self balance is equal to 1 or 0.
      */

--- a/contracts/lowLevelCallers/LowLevelETH.sol
+++ b/contracts/lowLevelCallers/LowLevelETH.sol
@@ -82,29 +82,4 @@ contract LowLevelETH {
 
         if (!status) revert ETHTransferFail();
     }
-
-    /**
-     * @notice Return ETH to the designated recipient if any is left in the payable call but leave 1 wei of ETH in the contract.
-     * @param recipient Recipient address
-     * @dev It does not revert if self balance is equal to 1 or 0.
-     */
-    function _returnETHIfAnyWithOneWeiLeft(address recipient) internal {
-        bool status;
-
-
-        assembly {
-            let selfBalance := selfbalance()
-
-            if lt(selfBalance, 2) {
-                status := true
-            }
-
-            if eq(status, false) {
-                status := call(gas(), recipient, sub(selfBalance, 1), 0, 0, 0, 0)
-            }
-        }
-
-
-        if (!status) revert ETHTransferFail();
-    }
 }

--- a/test/foundry/LowLevelETH.t.sol
+++ b/test/foundry/LowLevelETH.t.sol
@@ -20,10 +20,6 @@ contract ImplementedLowLevelETH is LowLevelETH {
     function transferETHAndReturnFundsExceptOneWei() external payable {
         _returnETHIfAnyWithOneWeiLeft();
     }
-
-    function transferETHAndReturnFundsExceptOneWeiToSpecificAddress(address recipient) external payable {
-        _returnETHIfAnyWithOneWeiLeft(recipient);
-    }
 }
 
 contract AlwaysReject {
@@ -131,33 +127,5 @@ contract LowLevelETHTest is TestParameters, TestHelpers {
         AlwaysReject alwaysReject = new AlwaysReject(lowLevelETH);
         vm.expectRevert(LowLevelETH.ETHTransferFail.selector);
         alwaysReject.transferETHAndReturnFundsExceptOneWei{value: amount}();
-    }
-
-    function testTransferETHAndReturnFundsExceptOneWeiToSpecificAddress(uint112 amount)
-        external
-        asPrankedUser(_sender)
-    {
-        vm.deal(_sender, amount);
-
-        if (amount > 1) {
-            lowLevelETH.transferETHAndReturnFundsExceptOneWeiToSpecificAddress{value: amount}(_recipient);
-            assertEq(_recipient.balance, amount - 1);
-            assertEq(address(lowLevelETH).balance, 1);
-        } else {
-            lowLevelETH.transferETHAndReturnFundsExceptOneWeiToSpecificAddress{value: amount}(_recipient);
-            assertEq(_recipient.balance, 0);
-            assertEq(address(lowLevelETH).balance, amount);
-        }
-    }
-
-    function testTransferETHAndReturnFundsExceptOneWeiToSpecificAddressFail(uint112 amount)
-        external
-        asPrankedUser(_sender)
-    {
-        vm.assume(amount > 1);
-        vm.deal(_sender, amount);
-        AlwaysReject alwaysReject = new AlwaysReject(lowLevelETH);
-        vm.expectRevert(LowLevelETH.ETHTransferFail.selector);
-        lowLevelETH.transferETHAndReturnFundsExceptOneWeiToSpecificAddress{value: amount}(address(alwaysReject));
     }
 }

--- a/test/foundry/LowLevelETH.t.sol
+++ b/test/foundry/LowLevelETH.t.sol
@@ -13,10 +13,6 @@ contract ImplementedLowLevelETH is LowLevelETH {
         _returnETHIfAny();
     }
 
-    function transferETHAndReturnFundsToSpecificAddress(address recipient) external payable {
-        _returnETHIfAny(recipient);
-    }
-
     function transferETHAndReturnFundsExceptOneWei() external payable {
         _returnETHIfAnyWithOneWeiLeft();
     }
@@ -88,23 +84,6 @@ contract LowLevelETHTest is TestParameters, TestHelpers {
         AlwaysReject alwaysReject = new AlwaysReject(lowLevelETH);
         vm.expectRevert(LowLevelETH.ETHTransferFail.selector);
         alwaysReject.transferETHAndReturnFunds{value: amount}();
-    }
-
-    function testTransferETHAndReturnFundsToSpecificAddress(uint112 amount) external asPrankedUser(_sender) {
-        vm.assume(amount > 0);
-        vm.deal(_sender, amount);
-        assertEq(_recipient.balance, 0);
-        lowLevelETH.transferETHAndReturnFundsToSpecificAddress{value: amount}(_recipient);
-        assertEq(_recipient.balance, amount);
-    }
-
-    function testTransferETHAndReturnFundsToSpecificAddressFail(uint112 amount) external asPrankedUser(_sender) {
-        // It only fails if ETH is transferred and activates the fallback for the recipient so it needs to be greater than 1
-        vm.assume(amount > 1);
-        vm.deal(_sender, amount);
-        AlwaysReject alwaysReject = new AlwaysReject(lowLevelETH);
-        vm.expectRevert(LowLevelETH.ETHTransferFail.selector);
-        lowLevelETH.transferETHAndReturnFundsToSpecificAddress{value: amount}(address(alwaysReject));
     }
 
     function testTransferETHAndReturnFundsExceptOneWei(uint112 amount) external asPrankedUser(_sender) {


### PR DESCRIPTION
I think we can drop `_returnETHIfAny` completely if we migrate to use `_returnETHIfAnyWithOneWeiLeft` in `contracts-exchange-v2` as well?