### PR TITLE
chore: Use more updated floating pragma

### DIFF
--- a/.solhint.json
+++ b/.solhint.json
@@ -1,7 +1,7 @@
 {
   "extends": "solhint:recommended",
   "rules": {
-    "compiler-version": ["error", "^0.8.0"],
+    "compiler-version": ["error", "^0.8.17"],
     "func-visibility": [{ "ignoreConstructors": true }],
     "func-name-mixedcase": "off",
     "reason-string": "off",

--- a/contracts/OwnableTwoSteps.sol
+++ b/contracts/OwnableTwoSteps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IOwnableTwoSteps} from "./interfaces/IOwnableTwoSteps.sol";
 

--- a/contracts/ReentrancyGuard.sol
+++ b/contracts/ReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IReentrancyGuard} from "./interfaces/IReentrancyGuard.sol";
 

--- a/contracts/SignatureChecker.sol
+++ b/contracts/SignatureChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IERC1271} from "./interfaces/generic/IERC1271.sol";
 import "./errors/SignatureCheckerErrors.sol";

--- a/contracts/errors/ETHTransferFail.sol
+++ b/contracts/errors/ETHTransferFail.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 error ETHTransferFail();

--- a/contracts/errors/GenericErrors.sol
+++ b/contracts/errors/GenericErrors.sol
@@ -1,4 +1,4 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 error NotAContract();

--- a/contracts/errors/SignatureCheckerErrors.sol
+++ b/contracts/errors/SignatureCheckerErrors.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 error BadSignatureS();
 error BadSignatureV(uint8 v);

--- a/contracts/interfaces/IOwnableTwoSteps.sol
+++ b/contracts/interfaces/IOwnableTwoSteps.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 /**
  * @title IOwnableTwoSteps

--- a/contracts/interfaces/IReentrancyGuard.sol
+++ b/contracts/interfaces/IReentrancyGuard.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 /**
  * @title IReentrancyGuard

--- a/contracts/interfaces/generic/IERC1155.sol
+++ b/contracts/interfaces/generic/IERC1155.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 interface IERC1155 {
     event TransferSingle(address indexed operator, address indexed from, address indexed to, uint256 id, uint256 value);

--- a/contracts/interfaces/generic/IERC1271.sol
+++ b/contracts/interfaces/generic/IERC1271.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 interface IERC1271 {
     function isValidSignature(bytes32 hash, bytes calldata signature) external view returns (bytes4 magicValue);

--- a/contracts/interfaces/generic/IERC165.sol
+++ b/contracts/interfaces/generic/IERC165.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 interface IERC165 {
     function supportsInterface(bytes4 interfaceId) external view returns (bool);

--- a/contracts/interfaces/generic/IERC20.sol
+++ b/contracts/interfaces/generic/IERC20.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 interface IERC20 {
     event Transfer(address indexed from, address indexed to, uint256 value);

--- a/contracts/interfaces/generic/IERC2981.sol
+++ b/contracts/interfaces/generic/IERC2981.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import "./IERC165.sol";
 

--- a/contracts/interfaces/generic/IERC721.sol
+++ b/contracts/interfaces/generic/IERC721.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 interface IERC721 {
     event Transfer(address indexed from, address indexed to, uint256 indexed tokenId);

--- a/contracts/lowLevelCallers/LowLevelERC1155Transfer.sol
+++ b/contracts/lowLevelCallers/LowLevelERC1155Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IERC1155} from "../interfaces/generic/IERC1155.sol";
 import {NotAContract} from "../errors/GenericErrors.sol";

--- a/contracts/lowLevelCallers/LowLevelERC20Approve.sol
+++ b/contracts/lowLevelCallers/LowLevelERC20Approve.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IERC20} from "../interfaces/generic/IERC20.sol";
 import {NotAContract} from "../errors/GenericErrors.sol";

--- a/contracts/lowLevelCallers/LowLevelERC20Transfer.sol
+++ b/contracts/lowLevelCallers/LowLevelERC20Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IERC20} from "../interfaces/generic/IERC20.sol";
 import {NotAContract} from "../errors/GenericErrors.sol";

--- a/contracts/lowLevelCallers/LowLevelERC721Transfer.sol
+++ b/contracts/lowLevelCallers/LowLevelERC721Transfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IERC721} from "../interfaces/generic/IERC721.sol";
 import {NotAContract} from "../errors/GenericErrors.sol";

--- a/contracts/lowLevelCallers/LowLevelETHReturnETHIfAny.sol
+++ b/contracts/lowLevelCallers/LowLevelETHReturnETHIfAny.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import "../errors/ETHTransferFail.sol";
 

--- a/contracts/lowLevelCallers/LowLevelETHReturnETHIfAnyExceptOneWei.sol
+++ b/contracts/lowLevelCallers/LowLevelETHReturnETHIfAnyExceptOneWei.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import "../errors/ETHTransferFail.sol";
 

--- a/contracts/lowLevelCallers/LowLevelETHTransfer.sol
+++ b/contracts/lowLevelCallers/LowLevelETHTransfer.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import "../errors/ETHTransferFail.sol";
 

--- a/contracts/lowLevelCallers/LowLevelWETH.sol
+++ b/contracts/lowLevelCallers/LowLevelWETH.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {IWETH} from "../interfaces/generic/IWETH.sol";
 

--- a/hardhat.config.ts
+++ b/hardhat.config.ts
@@ -33,7 +33,7 @@ const config: HardhatUserConfig = {
   solidity: {
     compilers: [
       {
-        version: "0.8.14",
+        version: "0.8.17",
         settings: { optimizer: { enabled: true, runs: 888888 } },
       },
       {

--- a/test/foundry/LowLevelERC1155Transfer.t.sol
+++ b/test/foundry/LowLevelERC1155Transfer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelERC1155Transfer} from "../../contracts/lowLevelCallers/LowLevelERC1155Transfer.sol";
 import {NotAContract} from "../../contracts/errors/GenericErrors.sol";

--- a/test/foundry/LowLevelERC20Approve.t.sol
+++ b/test/foundry/LowLevelERC20Approve.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelERC20Approve} from "../../contracts/lowLevelCallers/LowLevelERC20Approve.sol";
 import {NotAContract} from "../../contracts/errors/GenericErrors.sol";

--- a/test/foundry/LowLevelERC20Transfer.t.sol
+++ b/test/foundry/LowLevelERC20Transfer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelERC20Transfer} from "../../contracts/lowLevelCallers/LowLevelERC20Transfer.sol";
 import {NotAContract} from "../../contracts/errors/GenericErrors.sol";

--- a/test/foundry/LowLevelERC721Transfer.t.sol
+++ b/test/foundry/LowLevelERC721Transfer.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelERC721Transfer} from "../../contracts/lowLevelCallers/LowLevelERC721Transfer.sol";
 import {NotAContract} from "../../contracts/errors/GenericErrors.sol";

--- a/test/foundry/LowLevelETH.t.sol
+++ b/test/foundry/LowLevelETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelETHTransfer} from "../../contracts/lowLevelCallers/LowLevelETHTransfer.sol";
 import {LowLevelETHReturnETHIfAny} from "../../contracts/lowLevelCallers/LowLevelETHReturnETHIfAny.sol";

--- a/test/foundry/LowLevelWETH.t.sol
+++ b/test/foundry/LowLevelWETH.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {WETH} from "solmate/src/tokens/WETH.sol";
 import {LowLevelWETH} from "../../contracts/lowLevelCallers/LowLevelWETH.sol";

--- a/test/foundry/OwnableTwoSteps.t.sol
+++ b/test/foundry/OwnableTwoSteps.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {OwnableTwoSteps} from "../../contracts/OwnableTwoSteps.sol";
 import {IOwnableTwoSteps} from "../../contracts/interfaces/IOwnableTwoSteps.sol";

--- a/test/foundry/ReentrancyGuard.t.sol
+++ b/test/foundry/ReentrancyGuard.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {ReentrancyGuard, IReentrancyGuard} from "../../contracts/ReentrancyGuard.sol";
 import {TestHelpers} from "./utils/TestHelpers.sol";

--- a/test/foundry/SignatureChecker.t.sol
+++ b/test/foundry/SignatureChecker.t.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {ERC1271Contract} from "./utils/ERC1271Contract.sol";
 import {PublicSignatureChecker} from "./utils/PublicSignatureChecker.sol";

--- a/test/foundry/USDTLowLevelERC20Test.sol
+++ b/test/foundry/USDTLowLevelERC20Test.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.0;
+pragma solidity ^0.8.17;
 
 import {LowLevelERC20Approve} from "../../contracts/lowLevelCallers/LowLevelERC20Approve.sol";
 import {LowLevelERC20Transfer} from "../../contracts/lowLevelCallers/LowLevelERC20Transfer.sol";

--- a/test/foundry/utils/ERC1271Contract.sol
+++ b/test/foundry/utils/ERC1271Contract.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity 0.8.14;
+pragma solidity 0.8.17;
 
 import {IERC1271} from "../../../contracts/interfaces/generic/IERC1271.sol";
 

--- a/test/foundry/utils/PublicSignatureChecker.sol
+++ b/test/foundry/utils/PublicSignatureChecker.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {SignatureChecker} from "../../../contracts/SignatureChecker.sol";
 

--- a/test/foundry/utils/TestHelpers.sol
+++ b/test/foundry/utils/TestHelpers.sol
@@ -1,5 +1,5 @@
 // SPDX-License-Identifier: MIT
-pragma solidity ^0.8.14;
+pragma solidity ^0.8.17;
 
 import {Test} from "../../../lib/forge-std/src/Test.sol";
 


### PR DESCRIPTION
Since we are using 0.8.17 for both V2 and the aggregator, we should just make our libs' floating pragma to be at least 0.8.17 as well?