### PR TITLE
fix: Error name missing Fail suffix

### DIFF
--- a/contracts/errors/LowLevelErrors.sol
+++ b/contracts/errors/LowLevelErrors.sol
@@ -34,4 +34,4 @@ error ERC1155SafeTransferFromFail();
 /**
  * @notice It is emitted if the ERC1155 safeBatchTransferFrom fails.
  */
-error ERC1155SafeBatchTransferFrom();
+error ERC1155SafeBatchTransferFromFail();

--- a/contracts/lowLevelCallers/LowLevelERC1155Transfer.sol
+++ b/contracts/lowLevelCallers/LowLevelERC1155Transfer.sol
@@ -5,7 +5,7 @@ pragma solidity ^0.8.17;
 import {IERC1155} from "../interfaces/generic/IERC1155.sol";
 
 // Errors
-import {ERC1155SafeTransferFromFail, ERC1155SafeBatchTransferFrom} from "../errors/LowLevelErrors.sol";
+import {ERC1155SafeTransferFromFail, ERC1155SafeBatchTransferFromFail} from "../errors/LowLevelErrors.sol";
 import {NotAContract} from "../errors/GenericErrors.sol";
 
 /**
@@ -64,7 +64,7 @@ contract LowLevelERC1155Transfer {
         );
 
         if (!status) {
-            revert ERC1155SafeBatchTransferFrom();
+            revert ERC1155SafeBatchTransferFromFail();
         }
     }
 }

--- a/test/foundry/LowLevelERC1155Transfer.t.sol
+++ b/test/foundry/LowLevelERC1155Transfer.t.sol
@@ -3,7 +3,7 @@ pragma solidity ^0.8.17;
 
 import {LowLevelERC1155Transfer} from "../../contracts/lowLevelCallers/LowLevelERC1155Transfer.sol";
 import {NotAContract} from "../../contracts/errors/GenericErrors.sol";
-import {ERC1155SafeTransferFromFail, ERC1155SafeBatchTransferFrom} from "../../contracts/errors/LowLevelErrors.sol";
+import {ERC1155SafeTransferFromFail, ERC1155SafeBatchTransferFromFail} from "../../contracts/errors/LowLevelErrors.sol";
 import {MockERC721} from "../mock/MockERC721.sol";
 import {MockERC1155} from "../mock/MockERC1155.sol";
 import {TestHelpers} from "./utils/TestHelpers.sol";
@@ -138,7 +138,7 @@ contract LowLevelERC1155TransferTest is TestParameters, TestHelpers {
         tokenIds[0] = tokenId0;
         tokenIds[1] = tokenId1;
 
-        vm.expectRevert(ERC1155SafeBatchTransferFrom.selector);
+        vm.expectRevert(ERC1155SafeBatchTransferFromFail.selector);
         lowLevelERC1155Transfer.safeBatchTransferFromERC1155(
             address(mockERC721),
             _sender,


### PR DESCRIPTION
ERC1155SafeBatchTransferFrom -> ERC1155SafeBatchTransferFromFail